### PR TITLE
hotfix: Fix 504 timeout errors (reduce timeouts)

### DIFF
--- a/lib/agent-analyzer.ts
+++ b/lib/agent-analyzer.ts
@@ -11,10 +11,10 @@ const anthropic = new Anthropic({
 });
 
 // Maximum tool calls to prevent timeout (10s Vercel limit)
-const MAX_TOOL_CALLS = 5;
-const MAX_TOOL_LOOP_TIME_MS = 7000; // Reserve 2-3s for final Claude response
-const MAX_ANALYSIS_TIME_MS = 9000; // Overall budget (leave 1s for processing)
-const MIN_FALLBACK_TIME_MS = 3000; // Minimum time needed for fallback analysis
+const MAX_TOOL_CALLS = 3; // Reduced from 5 to prevent timeout
+const MAX_TOOL_LOOP_TIME_MS = 5000; // Reduced from 7000 - Reserve 3-4s for final Claude response
+const MAX_ANALYSIS_TIME_MS = 8000; // Reduced from 9000 - Overall budget (leave 2s for processing)
+const MIN_FALLBACK_TIME_MS = 2500; // Reduced from 3000 - Minimum time needed for fallback analysis
 
 /**
  * System prompt for agentic analysis with tool use (v1.1)

--- a/lib/threat-intel.ts
+++ b/lib/threat-intel.ts
@@ -8,7 +8,7 @@
  *
  * Adapted for Vercel serverless:
  * - Uses Upstash Redis for caching (not NodeCache)
- * - Aggressive timeouts (3s per service)
+ * - Aggressive timeouts (2s per service to avoid Vercel 10s limit)
  * - Parallel execution with Promise.allSettled
  * - Graceful degradation if APIs unavailable
  */
@@ -138,7 +138,7 @@ export class ThreatIntelService {
       this.virusTotalClient = axios.create({
         baseURL: 'https://www.virustotal.com/api/v3',
         headers: { 'x-apikey': process.env.VIRUSTOTAL_API_KEY },
-        timeout: 3000, // 3s timeout for serverless
+        timeout: 2000, // 2s timeout to avoid Vercel 10s limit
       });
       hasAnyClient = true;
     }
@@ -148,7 +148,7 @@ export class ThreatIntelService {
       this.abuseIpDbClient = axios.create({
         baseURL: 'https://api.abuseipdb.com/api/v2',
         headers: { Key: process.env.ABUSEIPDB_API_KEY },
-        timeout: 3000,
+        timeout: 2000, // 2s timeout to avoid Vercel 10s limit
       });
       hasAnyClient = true;
     }
@@ -158,7 +158,7 @@ export class ThreatIntelService {
       this.urlScanClient = axios.create({
         baseURL: 'https://urlscan.io/api/v1',
         headers: { 'API-Key': process.env.URLSCAN_API_KEY },
-        timeout: 3000,
+        timeout: 2000, // 2s timeout to avoid Vercel 10s limit
       });
       hasAnyClient = true;
     }


### PR DESCRIPTION
## Urgent Fix: 504 Timeout Errors

**Problem:** Analysis timing out after 10s (Vercel Hobby tier limit)

**Root Cause:** External API calls (3s each) + multiple tool calls exceeded budget

## Changes

- ✅ Reduced MAX_TOOL_CALLS: 5 → 3
- ✅ Reduced MAX_TOOL_LOOP_TIME_MS: 7000ms → 5000ms  
- ✅ Reduced MAX_ANALYSIS_TIME_MS: 9000ms → 8000ms
- ✅ Reduced external API timeouts: 3s → 2s
  - VirusTotal: 3s → 2s
  - AbuseIPDB: 3s → 2s
  - URLScan: 3s → 2s

## Impact

✅ Target <5s for most emails
✅ Leaves 1-2s buffer before Vercel 10s limit
✅ All tests passing (52/52)
✅ Still thorough analysis with graceful fallback

## Testing

Tested with all 52 unit tests - all passing

## Deploy ASAP

This fixes production 504 errors blocking email analysis.